### PR TITLE
Updated to work with PyCharm 2019.1.3:

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ NOTE that my implementation of changing view is inefficient (but fluent enough) 
 
 All the dependencies are available via `pip install`.
 
+Also required is `sudo apt-get install python3-tk`.
+
 ## One More Thing
 
 If this repo is used in any publications or projects, please let me know. I would be happy and encouraged =)

--- a/amc_parser.py
+++ b/amc_parser.py
@@ -1,8 +1,9 @@
 import numpy as np
+import matplotlib
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 from transforms3d.euler import euler2mat
 from mpl_toolkits.mplot3d import Axes3D
-
 
 class Joint:
   def __init__(self, name, direction, length, axis, dof, limits):
@@ -248,7 +249,7 @@ def test_all():
     asf_path = '%s/%s/%s.asf' % (lv0, lv1, lv1)
     print('parsing %s' % asf_path)
     joints = parse_asf(asf_path)
-    motions = parse_amc('./nopose.amc')
+    motions = parse_amc('./data/01/01_01.amc')
     joints['root'].set_motion(motions[0])
     joints['root'].draw()
 


### PR DESCRIPTION
- Set matplotlib to use TkAgg instead of Agg so pictures/animations get
  displayed
- Changed nonexistent nopose.amc to data/01/01_01.amc
- Add python3-tk dependency note to README